### PR TITLE
Fix word page params and image style

### DIFF
--- a/src/app/[letter]/[word]/page.tsx
+++ b/src/app/[letter]/[word]/page.tsx
@@ -1,12 +1,12 @@
 import WordDefinition from "@/components/WordDefinition";
 import { words } from "@/words";
 
-export default async function WordPage({
+export default function WordPage({
   params,
 }: {
-  params: Promise<{ letter: string; word: string }>;
+  params: { letter: string; word: string };
 }) {
-  const { letter: letterParam, word: wordParam } = await params;
+  const { letter: letterParam, word: wordParam } = params;
   const word = words[letterParam][wordParam];
 
   return (

--- a/src/components/FoundInBook.tsx
+++ b/src/components/FoundInBook.tsx
@@ -19,7 +19,12 @@ export default function FoundInBook({ reference }: { reference: Reference }) {
         )}
       >
         <div className="relative w-full max-w-[100px] h-40">
-          <Image src={cover} alt={title} fill objectFit="contain" />
+          <Image
+            src={cover}
+            alt={title}
+            fill
+            style={{ objectFit: "contain" }}
+          />
         </div>
         <div>
           <h4 className="text-2xl font-bold">{title}</h4>


### PR DESCRIPTION
## Summary
- fix parameter usage in dynamic `[word]` page
- use `style` to control `Image` object fit in `FoundInBook`

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_b_6866f821fba8832585215b78197afd35