### PR TITLE
feat: preload book covers with blurred placeholders

### DIFF
--- a/src/components/FoundInBook.tsx
+++ b/src/components/FoundInBook.tsx
@@ -22,6 +22,8 @@ export default function FoundInBook({ reference }: { reference: Reference }) {
           <Image
             src={cover}
             alt={title}
+            placeholder="blur"
+            priority
             fill
             style={{ objectFit: "contain" }}
           />

--- a/src/components/__tests__/FoundInBook.test.tsx
+++ b/src/components/__tests__/FoundInBook.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import type { StaticImageData } from 'next/image';
 import FoundInBook from '../FoundInBook';
 
 jest.mock('next/image', () => ({
@@ -9,7 +10,7 @@ jest.mock('next/image', () => ({
 describe('FoundInBook', () => {
   it('shows book info and excerpt', () => {
     const reference = {
-      book: { title: 'Title', author: 'Auth', cover: '/img.png' },
+      book: { title: 'Title', author: 'Auth', cover: '/img.png' as unknown as StaticImageData },
       excerpt: <>Quote</>,
     };
     render(<FoundInBook reference={reference} />);

--- a/src/components/__tests__/WordDefinition.extra.test.tsx
+++ b/src/components/__tests__/WordDefinition.extra.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import WordDefinition from '../WordDefinition';
 import { Word } from '@/types';
+import type { StaticImageData } from 'next/image';
 
 const mockFound = jest.fn(() => <div data-testid="found" />);
 jest.mock('../FoundInBook', () => ({ __esModule: true, default: (props: any) => mockFound(props) }));
@@ -24,7 +25,7 @@ describe('WordDefinition additional', () => {
       type: 'noun',
       definitions: ['d'],
       reference: {
-        book: { title: 'T', author: 'A', cover: '/c.png' },
+        book: { title: 'T', author: 'A', cover: '/c.png' as unknown as StaticImageData },
         excerpt: <>quote</>,
       },
     };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,9 @@
+import { StaticImageData } from "next/image";
+
 export type Book = {
   title: string;
   author: string;
-  cover: string;
+  cover: StaticImageData;
 };
 
 export interface Reference {

--- a/src/words.tsx
+++ b/src/words.tsx
@@ -1,4 +1,10 @@
 import { Book, Word } from "./types";
+import itCover from "../public/images/it.png";
+import aLittleLifeCover from "../public/images/a_little_life.jpg";
+import antimemeticsCover from "../public/images/there_is_no_antimemetics_division.png";
+import changeMindCover from "../public/images/how_to_change_your_mind.png";
+import daisyJonesCover from "../public/images/daisy_jones_and_the_six.png";
+import homoDeusCover from "../public/images/homo_deus.jpg";
 
 type BookTitles =
   | "it"
@@ -12,32 +18,32 @@ const books: Record<BookTitles, Book> = {
   it: {
     title: "It",
     author: "Stephen King",
-    cover: "/images/it.png",
+    cover: itCover,
   },
   a_little_life: {
     title: "A Little Life",
     author: "Hanya Yanagihara",
-    cover: "/images/a_little_life.jpg",
+    cover: aLittleLifeCover,
   },
   there_is_no_antimemetics_division: {
     title: "There Is No Antimemetics Division",
     author: "qntm",
-    cover: "/images/there_is_no_antimemetics_division.png",
+    cover: antimemeticsCover,
   },
   how_to_change_your_mind: {
     title: "How to Change Your Mind",
     author: "Michael Pollan",
-    cover: "/images/how_to_change_your_mind.png",
+    cover: changeMindCover,
   },
   daisy_jones_and_the_six: {
     title: "Daisy Jones & the Six: A Novel",
     author: "Taylor Jenkins Reid",
-    cover: "/images/daisy_jones_and_the_six.png",
+    cover: daisyJonesCover,
   },
   homo_deus: {
     title: "Homo Deus: A Brief History of Tomorrow",
     author: "Yuval Noah Harari",
-    cover: "/images/homo_deus.jpg",
+    cover: homoDeusCover,
   },
 };
 


### PR DESCRIPTION
## Summary
- preload book covers via Next `Image` priority
- use blurred placeholders for smoother loading
- switch `Book.cover` type to `StaticImageData`
- update book data to import local images
- adjust unit tests for new cover type

## Testing
- `npm run lint`
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68671de40bc883259006671e220c1e73