### PR TITLE
fix: sort words within letters

### DIFF
--- a/src/__tests__/words.test.ts
+++ b/src/__tests__/words.test.ts
@@ -1,0 +1,14 @@
+import { words, letters } from '@/words';
+
+describe('words data sorting', () => {
+  it('exports letters alphabetically', () => {
+    expect(letters).toEqual([...letters].sort());
+  });
+
+  it('exports words alphabetically within each letter', () => {
+    for (const letter of letters) {
+      const wordKeys = Object.keys(words[letter]);
+      expect(wordKeys).toEqual([...wordKeys].sort());
+    }
+  });
+});

--- a/src/words.tsx
+++ b/src/words.tsx
@@ -483,8 +483,14 @@ const allWords: Record<string, Record<string, Word>> = {
 // and words sorted alphabetically
 export const words = Object.keys(allWords)
   .sort()
-  .reduce((acc, key) => {
-    acc[key] = allWords[key];
+  .reduce((acc, letter) => {
+    const sortedWords = Object.keys(allWords[letter])
+      .sort()
+      .reduce((letterAcc, wordKey) => {
+        letterAcc[wordKey] = allWords[letter][wordKey];
+        return letterAcc;
+      }, {} as Record<string, Word>);
+    acc[letter] = sortedWords;
     return acc;
   }, {} as Record<string, Record<string, Word>>);
 


### PR DESCRIPTION
## Summary
- ensure word data is sorted alphabetically by letter and by word
- test that `words` and `letters` exports are sorted

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6867254e204c83258fc8cb60d6c534b4