### PR TITLE
feat: add searchable word lookup

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,6 +2,7 @@
 import classNames from "classnames";
 import { vidaloka } from "@/fonts";
 import { usePathname } from "next/navigation";
+import SearchBar from "./SearchBar";
 
 // Local font defined in src/fonts.ts
 
@@ -30,6 +31,7 @@ export default function Header() {
           Words
         </a>
       </h1>
+      <SearchBar />
       {/* TODO: Implement language toggle for Portuguese/English */}
       {/* <FlagToggle /> */}
     </div>

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { wordEntries } from "@/words";
+import classNames from "classnames";
+import { vidaloka } from "@/fonts";
+
+interface WordEntry {
+  letter: string;
+  slug: string;
+  word: string;
+  customPage?: string;
+}
+
+export default function SearchBar() {
+  const [query, setQuery] = useState("");
+
+  const entries = useMemo(() => wordEntries.map((e) => ({
+    letter: e.letter,
+    slug: e.slug,
+    word: e.word.word,
+    customPage: e.word.withCustomPage,
+  })), []);
+
+  const results = useMemo(() => {
+    if (!query) return [] as WordEntry[];
+    const lower = query.toLowerCase();
+    return entries.filter((e) => e.word.toLowerCase().includes(lower));
+  }, [query, entries]);
+
+  return (
+    <div className="relative w-40 md:w-60">
+      <input
+        type="text"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="Search"
+        aria-label="Search words"
+        className={classNames(
+          "w-full border border-neutral-300 rounded-md px-2 py-1 text-lg",
+          vidaloka.className
+        )}
+      />
+      {query && results.length > 0 && (
+        <ul className="absolute z-10 mt-1 w-full max-h-60 overflow-auto bg-champagne shadow-normal rounded-md border border-neutral-300">
+          {results.map((e) => (
+            <li key={`${e.letter}-${e.slug}`}>
+              <Link
+                href={e.customPage ?? `/${e.letter}/${e.slug}`}
+                className="block px-2 py-1 hover:bg-beige"
+                onClick={() => setQuery("")}
+              >
+                {e.word}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/__tests__/SearchBar.test.tsx
+++ b/src/components/__tests__/SearchBar.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import SearchBar from '../SearchBar';
+
+jest.mock('next/link', () => ({ __esModule: true, default: (props: any) => <a {...props} /> }));
+
+describe('SearchBar', () => {
+  it('filters results and navigates to word page', () => {
+    render(<SearchBar />);
+    const input = screen.getByRole('textbox', { name: /search words/i });
+    fireEvent.change(input, { target: { value: 'ineff' } });
+    const link = screen.getByRole('link', { name: /ineffable/i });
+    expect(link).toHaveAttribute('href', '/i/ineffable');
+  });
+});

--- a/src/words.tsx
+++ b/src/words.tsx
@@ -489,3 +489,11 @@ export const words = Object.keys(allWords)
   }, {} as Record<string, Record<string, Word>>);
 
 export const letters = Object.keys(words);
+
+export const wordEntries = Object.keys(words).flatMap((letter) =>
+  Object.keys(words[letter]).map((slug) => ({
+    letter,
+    slug,
+    word: words[letter][slug],
+  }))
+);


### PR DESCRIPTION
## Summary
- implement a new `SearchBar` component to filter words
- expose `wordEntries` for easier search
- integrate search bar in the header
- test search functionality

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68672583abec8325af1835bd643f8561