### PR TITLE
fix: keep site header sticky

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -54,7 +54,7 @@ export default function RootLayout({
     <html lang="en" className="bg-champagne">
       <body
         className={classNames(
-          "bg-fuzz_tinted text-rich-black relative min-h-screen w-full max-h-screen flex flex-col bg-blend-multiply",
+          "bg-fuzz_tinted text-rich-black relative min-h-screen w-full flex flex-col bg-blend-multiply",
           inter.className
         )}
       >


### PR DESCRIPTION
## Summary
- ensure the page body can grow beyond the viewport

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68672b17af9483258097637bef2623ba