### PR TITLE
feat: add 3d popup animation

### DIFF
--- a/src/components/WordPopUpBox.tsx
+++ b/src/components/WordPopUpBox.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { Word } from "@/types";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import classNames from "classnames";
 import { words, letters } from "@/words";
 import { TbX } from "react-icons/tb";
 import { GiRollingDices } from "react-icons/gi";
@@ -16,9 +17,11 @@ export default function WordPopUpBox({
 }) {
   const modalRef = useRef<HTMLDivElement | null>(null);
   const [currentWord, setCurrentWord] = useState<Word>(word);
+  const [closing, setClosing] = useState(false);
 
   useEffect(() => {
     setCurrentWord(word);
+    setClosing(false);
   }, [word]);
 
   const getRandomWord = () => {
@@ -31,16 +34,23 @@ export default function WordPopUpBox({
     setCurrentWord(getRandomWord());
   };
 
+  const closeWithAnimation = useCallback(() => {
+    setClosing(true);
+    setTimeout(() => {
+      closeModal?.();
+    }, 500);
+  }, [closeModal]);
+
   useEffect(() => {
     const handleClick = (event: MouseEvent) => {
       if (event.target === event.currentTarget) {
-        closeModal?.();
+        closeWithAnimation();
       }
     };
 
     const handleEscape = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
-        closeModal?.();
+        closeWithAnimation();
       }
     };
 
@@ -56,21 +66,26 @@ export default function WordPopUpBox({
       }
       document.removeEventListener("keydown", handleEscape);
     };
-  }, [closeModal]);
+  }, [closeWithAnimation]);
 
   return (
     <div
       id="modal-backdrop"
       className="fixed inset-0 bg-black bg-opacity-20 z-40"
+      style={{ perspective: "1000px" }}
       onClick={(e) => e.stopPropagation()}
     >
       <div
         ref={modalRef}
-        className="w-full overflow-y-auto max-w-screen-md max-h-[85vh] top-[10%] left-1/2 transform -translate-x-1/2 py-4 px-8 bg-champagne rounded-lg z-50 fixed"
+        className={classNames(
+          "w-full overflow-y-auto max-w-screen-md max-h-[85vh] top-[10%] left-1/2 transform -translate-x-1/2 py-4 px-8 bg-champagne rounded-lg z-50 fixed",
+          closing ? "animate-card-out" : "animate-card-in"
+        )}
+        style={{ transformStyle: "preserve-3d" }}
         onClick={(e) => e.stopPropagation()}
       >
         <button
-          onClick={closeModal}
+          onClick={closeWithAnimation}
           aria-label="Close"
           className="absolute top-4 right-4 text-2xl opacity-60 hover:opacity-100"
         >

--- a/src/components/__tests__/LetterSegment.test.tsx
+++ b/src/components/__tests__/LetterSegment.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
 import LetterSegment from '../LetterSegment';
 import { words } from '@/words';
 
@@ -12,15 +13,22 @@ describe('LetterSegment', () => {
   });
 
   it('opens and closes popup on button click and links when custom page', () => {
+    jest.useFakeTimers();
     const { getByRole } = render(<LetterSegment letter="i" />);
     const link = getByRole('link', { name: /interstitial/i });
     expect(link).toHaveAttribute('href', '/word/interstitial');
     const button = getByRole('button', { name: /ineffable/i });
     expect(document.getElementById('modal-backdrop')).toBeNull();
-    fireEvent.click(button);
+    act(() => {
+      fireEvent.click(button);
+    });
     const backdrop = document.getElementById('modal-backdrop')!;
     expect(backdrop).not.toBeNull();
-    fireEvent.click(backdrop);
+    act(() => {
+      fireEvent.click(backdrop);
+      jest.runAllTimers();
+    });
     expect(document.getElementById('modal-backdrop')).toBeNull();
+    jest.useRealTimers();
   });
 });

--- a/src/components/__tests__/WordPopUpBox.test.tsx
+++ b/src/components/__tests__/WordPopUpBox.test.tsx
@@ -1,4 +1,4 @@
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import WordPopUpBox from '../WordPopUpBox';
 import { Word } from '@/types';
 
@@ -10,14 +10,18 @@ const word: Word = {
 };
 
 describe('WordPopUpBox', () => {
-  it('calls closeModal when backdrop clicked or Escape pressed', () => {
+  it('calls closeModal when backdrop clicked or Escape pressed', async () => {
+    jest.useFakeTimers();
     const closeModal = jest.fn();
     render(<WordPopUpBox word={word} closeModal={closeModal} />);
     const backdrop = document.getElementById('modal-backdrop')!;
     fireEvent.click(backdrop);
-    expect(closeModal).toHaveBeenCalledTimes(1);
+    jest.runAllTimers();
+    await waitFor(() => expect(closeModal).toHaveBeenCalledTimes(1));
     fireEvent.keyDown(document, { key: 'Escape' });
-    expect(closeModal).toHaveBeenCalledTimes(2);
+    jest.runAllTimers();
+    await waitFor(() => expect(closeModal).toHaveBeenCalledTimes(2));
+    jest.useRealTimers();
   });
 
   it('ignores keydown events other than Escape', () => {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -22,6 +22,20 @@ const config: Config = {
         "3d": "rgba(50, 50, 93, 0.25) 0px 50px 100px -20px, rgba(0, 0, 0, 0.3) 0px 30px 60px -30px, rgba(10, 37, 64, 0.35) 0px -2px 6px 0px inset",
         normal: "rgba(17, 12, 46, 0.15) 0px 48px 100px 0px",
       },
+      keyframes: {
+        "card-in": {
+          "0%": { transform: "rotateX(-90deg) scale(0.8)", opacity: "0" },
+          "100%": { transform: "rotateX(0deg) scale(1)", opacity: "1" },
+        },
+        "card-out": {
+          "0%": { transform: "rotateX(0deg) scale(1)", opacity: "1" },
+          "100%": { transform: "rotateX(90deg) scale(0.8)", opacity: "0" },
+        },
+      },
+      animation: {
+        "card-in": "card-in 0.5s ease-out forwards",
+        "card-out": "card-out 0.5s ease-in forwards",
+      },
       screens: {
         xs: "375px",
       },


### PR DESCRIPTION
## Summary
- animate WordPopUpBox opening and closing
- support custom keyframes for 3d card motion in Tailwind
- update tests for asynchronous closing

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68672acde2448325b34dd53fbfa3501e