### PR TITLE
fix: reset book cover when switching words

### DIFF
--- a/src/components/FoundInBook.tsx
+++ b/src/components/FoundInBook.tsx
@@ -20,6 +20,7 @@ export default function FoundInBook({ reference }: { reference: Reference }) {
       >
         <div className="relative w-full max-w-[100px] h-40">
           <Image
+            key={cover.src}
             src={cover}
             alt={title}
             placeholder="blur"


### PR DESCRIPTION
## Summary
- ensure the FoundInBook image resets when its `src` changes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68682c16f9388325a4c271a3d1167a48