### PR TITLE
fix: persist reference visibility

### DIFF
--- a/src/components/WordPopUpBox.tsx
+++ b/src/components/WordPopUpBox.tsx
@@ -20,6 +20,17 @@ export default function WordPopUpBox({
   const [showRefrence, setShowReference] = useState<boolean>(true);
 
   useEffect(() => {
+    const stored = localStorage.getItem("showReference");
+    if (stored !== null) {
+      setShowReference(stored === "true");
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem("showReference", String(showRefrence));
+  }, [showRefrence]);
+
+  useEffect(() => {
     setCurrentWord(word);
   }, [word]);
 

--- a/src/components/WordPopUpBox.tsx
+++ b/src/components/WordPopUpBox.tsx
@@ -17,14 +17,11 @@ export default function WordPopUpBox({
 }) {
   const modalRef = useRef<HTMLDivElement | null>(null);
   const [currentWord, setCurrentWord] = useState<Word>(word);
-  const [showRefrence, setShowReference] = useState<boolean>(true);
-
-  useEffect(() => {
+  const [showRefrence, setShowReference] = useState<boolean>(() => {
+    if (typeof window === "undefined") return true;
     const stored = localStorage.getItem("showReference");
-    if (stored !== null) {
-      setShowReference(stored === "true");
-    }
-  }, []);
+    return stored !== null ? stored === "true" : true;
+  });
 
   useEffect(() => {
     localStorage.setItem("showReference", String(showRefrence));

--- a/src/components/__tests__/WordDefinition.extra.test.tsx
+++ b/src/components/__tests__/WordDefinition.extra.test.tsx
@@ -29,7 +29,7 @@ describe('WordDefinition additional', () => {
         excerpt: <>quote</>,
       },
     };
-    render(<WordDefinition word={word} />);
+    render(<WordDefinition word={word} showReference />);
     expect(mockFound).toHaveBeenCalledWith({ reference: word.reference });
   });
 });

--- a/src/components/__tests__/WordPopUpBox.test.tsx
+++ b/src/components/__tests__/WordPopUpBox.test.tsx
@@ -1,6 +1,10 @@
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, waitFor, screen } from '@testing-library/react';
 import WordPopUpBox from '../WordPopUpBox';
 import { Word } from '@/types';
+import type { StaticImageData } from 'next/image';
+
+const mockFound = jest.fn(() => <div data-testid="found" />);
+jest.mock('../FoundInBook', () => ({ __esModule: true, default: (props: any) => mockFound(props) }));
 
 const word: Word = {
   word: 'Test',
@@ -9,7 +13,22 @@ const word: Word = {
   definitions: ['definition'],
 };
 
+const refWord: Word = {
+  word: 'Ref',
+  phonetic: '/r/',
+  type: 'noun',
+  definitions: ['d'],
+  reference: {
+    book: { title: 'T', author: 'A', cover: '/c.png' as unknown as StaticImageData },
+    excerpt: <>quote</>,
+  },
+};
+
 describe('WordPopUpBox', () => {
+  afterEach(() => {
+    localStorage.clear();
+    mockFound.mockClear();
+  });
   it('calls closeModal when backdrop clicked or Escape pressed', () => {
     const closeModal = jest.fn();
     render(<WordPopUpBox word={word} closeModal={closeModal} />);
@@ -57,5 +76,23 @@ describe('WordPopUpBox', () => {
     fireEvent.click(backdrop);
     expect(closeModal).not.toHaveBeenCalled();
     (document.getElementById as jest.Mock).mockRestore();
+  });
+
+  it('reads showReference from localStorage', async () => {
+    localStorage.setItem('showReference', 'false');
+    render(<WordPopUpBox word={refWord} />);
+    await waitFor(() => {
+      expect(screen.queryByTestId('found')).not.toBeInTheDocument();
+    });
+  });
+
+  it('updates localStorage when toggled', async () => {
+    localStorage.setItem('showReference', 'true');
+    render(<WordPopUpBox word={refWord} />);
+    const buttons = screen.getAllByRole('button', { name: 'Random word' });
+    fireEvent.click(buttons[1]);
+    await waitFor(() => {
+      expect(localStorage.getItem('showReference')).toBe('false');
+    });
   });
 });

--- a/src/components/__tests__/WordPopUpBox.test.tsx
+++ b/src/components/__tests__/WordPopUpBox.test.tsx
@@ -78,12 +78,10 @@ describe('WordPopUpBox', () => {
     (document.getElementById as jest.Mock).mockRestore();
   });
 
-  it('reads showReference from localStorage', async () => {
+  it('reads showReference from localStorage', () => {
     localStorage.setItem('showReference', 'false');
     render(<WordPopUpBox word={refWord} />);
-    await waitFor(() => {
-      expect(screen.queryByTestId('found')).not.toBeInTheDocument();
-    });
+    expect(screen.queryByTestId('found')).not.toBeInTheDocument();
   });
 
   it('updates localStorage when toggled', async () => {


### PR DESCRIPTION
## Summary
- persist the reference toggle preference in localStorage
- adjust tests for `WordDefinition` and `WordPopUpBox`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68683e308e78832588d5fbbaa86f7e62