### PR TITLE
feat: improve performance with lazy popups

### DIFF
--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -6,7 +6,10 @@ import { wordEntries } from "@/words";
 import classNames from "classnames";
 import { vidaloka } from "@/fonts";
 import Link from "next/link";
-import WordPopUpBox from "@/components/WordPopUpBox";
+import dynamic from "next/dynamic";
+const WordPopUpBox = dynamic(() => import("@/components/WordPopUpBox"), {
+  ssr: false,
+});
 import { Word } from "@/types";
 import { TbExternalLink } from "react-icons/tb";
 

--- a/src/components/FoundInBook.tsx
+++ b/src/components/FoundInBook.tsx
@@ -20,7 +20,7 @@ export default function FoundInBook({ reference }: { reference: Reference }) {
             src={cover}
             alt={title}
             placeholder="blur"
-            priority
+            loading="lazy"
             fill
             style={{ objectFit: "contain" }}
           />

--- a/src/components/LetterSegment/index.tsx
+++ b/src/components/LetterSegment/index.tsx
@@ -3,7 +3,10 @@
 import { words } from "@/words";
 import classNames from "classnames";
 import { vidaloka } from "@/fonts";
-import WordPopUpBox from "../WordPopUpBox";
+import dynamic from "next/dynamic";
+const WordPopUpBox = dynamic(() => import("../WordPopUpBox"), {
+  ssr: false,
+});
 import { useState } from "react";
 import { Word } from "@/types";
 import Link from "next/link";

--- a/src/components/WordDefinition.tsx
+++ b/src/components/WordDefinition.tsx
@@ -12,6 +12,7 @@ type Props = {
 
 export default function WordDefinition({ word, showReference }: Props) {
   if (!word) return null;
+  const show = showReference ?? true;
   const {
     word: wordLabel,
     phonetic,
@@ -46,7 +47,7 @@ export default function WordDefinition({ word, showReference }: Props) {
               </p>
             ))}
       </div>
-      {showReference && word.reference && (
+      {show && word.reference && (
         <FoundInBook reference={word.reference} />
       )}
     </div>

--- a/src/components/WordPopUpBox.tsx
+++ b/src/components/WordPopUpBox.tsx
@@ -63,6 +63,7 @@ export default function WordPopUpBox({
   return (
     <div
       id="modal-backdrop"
+      data-testid="modal-backdrop"
       className="fixed inset-0 bg-black bg-opacity-20 z-40 backdrop-blur-sm"
       onClick={(e) => e.stopPropagation()}
     >

--- a/src/components/__tests__/LetterSegment.test.tsx
+++ b/src/components/__tests__/LetterSegment.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import LetterSegment from '../LetterSegment';
 import { words } from '@/words';
 
@@ -11,16 +11,18 @@ describe('LetterSegment', () => {
     }
   });
 
-  it('opens and closes popup on button click and links when custom page', () => {
+  it('opens and closes popup on button click and links when custom page', async () => {
     const { getByRole } = render(<LetterSegment letter="i" />);
     const link = getByRole('link', { name: /interstitial/i });
     expect(link).toHaveAttribute('href', '/word/interstitial');
     const button = getByRole('button', { name: /ineffable/i });
-    expect(document.getElementById('modal-backdrop')).toBeNull();
+    expect(screen.queryByTestId('modal-backdrop')).toBeNull();
     fireEvent.click(button);
-    const backdrop = document.getElementById('modal-backdrop')!;
-    expect(backdrop).not.toBeNull();
+    const backdrop = await screen.findByTestId('modal-backdrop');
+    expect(backdrop).toBeInTheDocument();
     fireEvent.click(backdrop);
-    expect(document.getElementById('modal-backdrop')).toBeNull();
+    await waitFor(() =>
+      expect(screen.queryByTestId('modal-backdrop')).toBeNull()
+    );
   });
 });

--- a/src/components/__tests__/WordPopUpBox.test.tsx
+++ b/src/components/__tests__/WordPopUpBox.test.tsx
@@ -1,4 +1,4 @@
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 import WordPopUpBox from '../WordPopUpBox';
 import { Word } from '@/types';
 
@@ -13,7 +13,7 @@ describe('WordPopUpBox', () => {
   it('calls closeModal when backdrop clicked or Escape pressed', () => {
     const closeModal = jest.fn();
     render(<WordPopUpBox word={word} closeModal={closeModal} />);
-    const backdrop = document.getElementById('modal-backdrop')!;
+    const backdrop = screen.getByTestId('modal-backdrop');
     fireEvent.click(backdrop);
     expect(closeModal).toHaveBeenCalledTimes(1);
     fireEvent.keyDown(document, { key: 'Escape' });
@@ -38,7 +38,7 @@ describe('WordPopUpBox', () => {
   it('works safely without closeModal handler', () => {
     expect(() => {
       render(<WordPopUpBox word={word} />);
-      const backdrop = document.getElementById('modal-backdrop')!;
+      const backdrop = screen.getByTestId('modal-backdrop');
       fireEvent.click(backdrop);
       fireEvent.keyDown(document, { key: 'Escape' });
     }).not.toThrow();
@@ -53,7 +53,7 @@ describe('WordPopUpBox', () => {
         id === 'modal-backdrop' ? null : original(id)
       );
     render(<WordPopUpBox word={word} closeModal={closeModal} />);
-    const backdrop = document.querySelector('#modal-backdrop') as HTMLElement;
+    const backdrop = screen.getByTestId('modal-backdrop');
     fireEvent.click(backdrop);
     expect(closeModal).not.toHaveBeenCalled();
     (document.getElementById as jest.Mock).mockRestore();


### PR DESCRIPTION
## Summary
- lazily load word pop-up code with `next/dynamic`
- default `WordDefinition` to show book references
- allow book images to lazy load
- test updates for async pop-up rendering

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6868423fe084832591abffddb148273d