### PR TITLE
feat: add Guess This Word game

### DIFF
--- a/src/__tests__/validateGuess.test.ts
+++ b/src/__tests__/validateGuess.test.ts
@@ -1,0 +1,15 @@
+import { validateGuess } from '@/app/api/guess/validate';
+
+describe('validateGuess', () => {
+  it('interprets yes response', async () => {
+    const mockFetch = jest.fn(() =>
+      Promise.resolve({
+        json: () => Promise.resolve({ choices: [{ message: { content: 'YES' } }] }),
+      })
+    ) as any;
+
+    const result = await validateGuess('k', 'test', ['def'], 'guess', mockFetch);
+    expect(mockFetch).toHaveBeenCalled();
+    expect(result).toBe('YES');
+  });
+});

--- a/src/app/api/guess/route.ts
+++ b/src/app/api/guess/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { validateGuess } from './validate';
+
+export async function POST(req: NextRequest) {
+  try {
+    const { word, definitions, guess } = await req.json();
+    const key = process.env.OPENAI_API_KEY;
+    if (!key) {
+      return NextResponse.json({ error: 'Missing API key' }, { status: 500 });
+    }
+    const result = await validateGuess(key, word, definitions, guess);
+    return NextResponse.json({ result });
+  } catch (err) {
+    return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+  }
+}

--- a/src/app/api/guess/validate.ts
+++ b/src/app/api/guess/validate.ts
@@ -1,0 +1,35 @@
+export async function validateGuess(
+  apiKey: string,
+  word: string,
+  definitions: string[],
+  guess: string,
+  fetchFn: typeof fetch = fetch
+): Promise<string> {
+  const messages = [
+    {
+      role: 'system',
+      content:
+        'You are an assistant that checks if a user explanation matches the official definition. Reply only with "YES" or "NO".',
+    },
+    {
+      role: 'user',
+      content: `Word: ${word}\nDefinitions: ${definitions.join('; ')}\nUser explanation: ${guess}`,
+    },
+  ];
+  const response = await fetchFn('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: 'gpt-3.5-turbo',
+      temperature: 0,
+      max_tokens: 1,
+      messages,
+    }),
+  });
+  const data = await response.json();
+  const answer = data.choices?.[0]?.message?.content?.trim().toUpperCase();
+  return answer && answer.startsWith('Y') ? 'YES' : 'NO';
+}

--- a/src/app/guess/page.tsx
+++ b/src/app/guess/page.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useState } from 'react';
+import Image from 'next/image';
+import WordDefinition from '@/components/WordDefinition';
+import { wordEntries } from '@/words';
+import classNames from 'classnames';
+
+function randomEntry() {
+  return wordEntries[Math.floor(Math.random() * wordEntries.length)];
+}
+
+export default function GuessPage() {
+  const [entry, setEntry] = useState(() => randomEntry());
+  const [guess, setGuess] = useState('');
+  const [result, setResult] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setResult(null);
+    try {
+      const res = await fetch('/api/guess', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          word: entry.word.word,
+          definitions: entry.word.definitions?.filter(d => typeof d === 'string') ?? [],
+          guess,
+        }),
+      });
+      const data = await res.json();
+      setResult(data.result);
+    } catch {
+      setResult('NO');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const next = () => {
+    setEntry(randomEntry());
+    setGuess('');
+    setResult(null);
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-8 w-full max-w-screen-md mx-auto py-8">
+      <h1 className={classNames('text-4xl md:text-5xl font-bold')}>Guess This Word</h1>
+      {entry.word.reference && (
+        <Image
+          src={entry.word.reference.book.cover}
+          alt="book cover"
+          className="w-40 h-auto rounded-md"
+        />
+      )}
+      <h2 className="text-3xl md:text-4xl font-serif">{entry.word.word}</h2>
+      {!result && (
+        <form onSubmit={submit} className="flex flex-col items-center gap-4 w-full">
+          <textarea
+            value={guess}
+            onChange={(e) => setGuess(e.target.value)}
+            className="w-full p-3 border border-black rounded-md"
+            placeholder="Describe what this word means"
+            rows={3}
+          />
+          <button
+            type="submit"
+            disabled={loading || !guess.trim()}
+            className="bg-black text-white px-4 py-2 rounded-md disabled:opacity-50"
+          >
+            {loading ? 'Checking...' : 'Submit'}
+          </button>
+        </form>
+      )}
+      {result && (
+        <>
+          <div
+            className={classNames(
+              'text-5xl font-bold',
+              result === 'YES' ? 'text-green-600' : 'text-red-600'
+            )}
+          >
+            {result}
+          </div>
+          <WordDefinition word={entry.word} />
+          <button
+            onClick={next}
+            className="mt-4 bg-blue-600 text-white px-4 py-2 rounded-md animate-bounce"
+          >
+            Next Word
+          </button>
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create Guess This Word page with client-side interaction
- add API route to validate guesses via OpenAI
- factor out validation helper and unit test it

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6878017e8728832583dfbc98daaa577f